### PR TITLE
Feature/network streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,16 @@
 A convenient library for initiating and controlling video playback on [omxplayer](https://github.com/popcornmix/omxplayer) -- the command-line [OpenMAX](https://en.wikipedia.org/wiki/OpenMAX) media player built especially for Raspberry Pi -- via NodeJS.
 
 ## Check your GPU memory!
+
 If you intend to play more than 1 video simultaneously, you should make sure that your Raspberry Pi is configured with more than the default 64MB normally allocated to the GPU. Otherwise you will get strange crashes.
 
 To do it:
+
 ```
 sudo raspi-config
 ```
-...then pick `4 Performance Options`, then `P2 GPU Memory` and type a new value (128MB is good enough for 2 layers). 
+
+...then pick `4 Performance Options`, then `P2 GPU Memory` and type a new value (128MB is good enough for 2 layers).
 
 Reboot the machine.
 
@@ -27,7 +30,7 @@ Include the Player
 const Player = require('omxconductor')
 ```
 
-Instantiate the Player with media and optional settings (an object)
+Instantiate the Player with media (file path or network stream) and optional settings (an object)
 
 ```
 const player = new Player('media/bigbuckbunny.mp4', { loop: true })

--- a/demo/demo-netstream.js
+++ b/demo/demo-netstream.js
@@ -1,0 +1,70 @@
+const Player = require("omxconductor");
+
+const player = new Player("rtsp://sdb:SDB_2011@192.168.2.15:554/videoMain", {
+  loop: false,
+});
+console.log("omx config:\n", player.getSettings());
+
+player
+  .open()
+  .then((result) => {
+    console.log("open result:", result);
+
+    // this could be done here or on 'open' event
+    player.registerPositionTrigger(5000, async (actualPosition) => {
+      console.log("hit 5000ms trigger @", actualPosition);
+      // player.seekAbsolute(0)
+      // player.stop()
+      await player.pause();
+      setTimeout(() => {
+        console.log("resume now!");
+        player.resume();
+      }, 4000);
+    });
+  })
+  .catch((err) => {
+    console.error("error on open:", err);
+  });
+
+player.on("open", (result) => {
+  console.log("**************** open event:", result);
+});
+
+player.on("ready", (result) => {
+  console.log("**************** ready event:", result);
+
+  // EXAMPLE A: TRIGGER ON PROGRESS UPDATES YOURSELF
+  // player.on('progress', (progress) => {
+  //   console.log('progress event:', progress)
+  //   if (progress.progress >= 0.2) {
+  //     console.log('pause...')
+  //     player.pause()
+  //   }
+  // })
+});
+
+player.on("error", (err) => {
+  console.error("**************** error event:", err);
+  // process.exit(1)
+});
+
+player.on("stopped", () => {
+  console.log("**************** stopped event");
+});
+
+player.on("paused", () => {
+  console.log("**************** paused event");
+});
+
+player.on("resumed", () => {
+  console.log("**************** resumed event");
+});
+
+player.on("close", (result) => {
+  console.log("**************** pipe closed event:", result);
+  process.exit(0);
+});
+
+// player.on('progress', (info) => {
+//   console.log('progress all good:', info)
+// })

--- a/demo/demo-netstream.js
+++ b/demo/demo-netstream.js
@@ -10,6 +10,15 @@ player
   .then((result) => {
     console.log("open result:", result);
 
+    setTimeout(() => {
+      console.log("pause now; resume in 3s...");
+      player.pause();
+      setTimeout(() => {
+        console.log("resume now");
+        player.resume();
+      }, 3000);
+    }, 3000);
+
     // this could be done here or on 'open' event
     player.registerPositionTrigger(5000, async (actualPosition) => {
       console.log("hit 5000ms trigger @", actualPosition);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omxconductor",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Orchestrate omxplayer instances via NodeJS",
   "main": "dist/index.js",
   "keywords": [


### PR DESCRIPTION
This addresses the basic issue raised in https://github.com/RandomStudio/omxconductor/issues/5 - namely, the ability to play network streams inside of only files on disk.

This update would check for `fileOrUrl` (instead of the previous `file` string) and if it contains "udp://" or "rtsp://" it will

- not check if the "file" exists
- increase the interval for `waitForControl` significantly, because network streams may take a few seconds to get started

I have also included a `demo-netstream.js` demo which shows this working in practice (though currently there is a hardcoded URL which obviously will not work for ordinary users).